### PR TITLE
Feat: tenant access blocked opt out flag for `public` tenant

### DIFF
--- a/.changeset/fruity-spiders-attack.md
+++ b/.changeset/fruity-spiders-attack.md
@@ -1,0 +1,6 @@
+---
+"@supertokens-plugins/tenants-nodejs": minor
+"@supertokens-plugins/tenants-react": minor
+---
+
+Added support for allowPublicTenantAccess and added an overrideable shouldHaveTenantAccess fn

--- a/packages/tenants-nodejs/README.md
+++ b/packages/tenants-nodejs/README.md
@@ -54,6 +54,7 @@ SuperTokens.init({
 | `requireTenantCreationRequestApproval`| `boolean` | `true`  | Whether tenant creation requires approval from an admin                |
 | `enableTenantListAPI`                 | `boolean` | `false` | Enable the API to list all available tenants                           |
 | `createRolesOnInit`                   | `boolean` | `true`  | Automatically create required roles (TENANT_ADMIN, TENANT_MEMBER) on initialization |
+| `allowPublicTenantAccess`                       | `boolean` | `false` | Whether public tenant access should be allowed without an assigned role |
 | `emailDelivery`                       | `object`  | -       | Configure email delivery service and overrides                         |
 
 ## API Endpoints

--- a/packages/tenants-nodejs/src/plugin.ts
+++ b/packages/tenants-nodejs/src/plugin.ts
@@ -942,7 +942,6 @@ export const init = createPluginInitFunction<
                 // can access the tenant.
                 const additionalValidators = [
                   PermissionClaim.validators.includes(PERMISSIONS.TENANT_ACCESS),
-                  TenantAccessPresentClaim.validators.isTrue(),
                 ];
                 logDebugMessage("Adding tenant-access permission claim");
 
@@ -997,13 +996,20 @@ export const init = createPluginInitFunction<
                   ...input.accessTokenPayload,
                   ...(pluginConfig.requireNonPublicTenantAssociation
                     ? await MultipleTenantsPresentClaim.build(
-                        input.userId,
-                        input.recipeUserId,
-                        tenantId,
-                        input.accessTokenPayload,
-                        input.userContext,
-                      )
+                      input.userId,
+                      input.recipeUserId,
+                      tenantId,
+                      input.accessTokenPayload,
+                      input.userContext,
+                    )
                     : {}),
+                  ...(await TenantAccessPresentClaim.build(
+                    input.userId,
+                    input.recipeUserId,
+                    tenantId,
+                    input.accessTokenPayload,
+                    input.userContext,
+                  )),
                 };
 
                 return originalImplementation.createNewSession({

--- a/packages/tenants-nodejs/src/plugin.ts
+++ b/packages/tenants-nodejs/src/plugin.ts
@@ -31,7 +31,7 @@ import { getOverrideableTenantFunctionImplementation } from "./pluginImplementat
 import { EmailDeliveryInterface } from "supertokens-node/lib/build/ingredients/emaildelivery/types";
 import { DefaultPluginEmailService } from "./defaultEmailService";
 
-const { getUser, RecipeUserId } = supertokens;
+const { RecipeUserId } = supertokens;
 
 export const init = createPluginInitFunction<
   SuperTokensPlugin,
@@ -51,6 +51,7 @@ export const init = createPluginInitFunction<
     // This defaults to `false` and is only enabled if the `requireNonPublicTenantAssociation`
     // is set to `true`.
     const MULTIPLE_TENANTS_PRESENT_CLAIM_ID = "stpl-tm-ta";
+    const TENANT_ACCESS_CLAIM_ID = "stpl-tm-access";
     const MultipleTenantsPresentClaim = new BooleanClaim({
       key: MULTIPLE_TENANTS_PRESENT_CLAIM_ID,
       fetchValue: async (userId, rId, tId, cP, userContext) => {
@@ -68,6 +69,18 @@ export const init = createPluginInitFunction<
         }
 
         return userDetails.tenantIds.some((tenantId) => tenantId !== "public");
+      },
+    });
+
+    const TenantAccessPresentClaim = new BooleanClaim({
+      key: TENANT_ACCESS_CLAIM_ID,
+      fetchValue: async (userId, rId, tId, cP, userContext) => {
+        if (pluginConfig.allowPublicTenantAccess && tId === "public") {
+          return true;
+        }
+
+        const { canAccess } = await implementation.shouldHaveTenantAccess(userId, tId, userContext);
+        return canAccess;
       },
     });
 
@@ -841,41 +854,15 @@ export const init = createPluginInitFunction<
                   };
                 }
 
-                // Check if the user has the role of member or admin in the tenant.
-                const roles = (await UserRoles.getRolesForUser(tenantId, session.getUserId(userContext), userContext))
-                  .roles;
-                if (roles.length === 0) {
+                const { canAccess: canAccessTenant, reason } = await implementation.shouldHaveTenantAccess(
+                  session.getUserId(userContext),
+                  tenantId,
+                  userContext,
+                );
+                if (!canAccessTenant) {
                   return {
                     status: "ERROR_NOT_ALLOWED",
-                    message: "Cannot switch to tenant, not enough roles",
-                  };
-                }
-
-                const allPermissions: string[] = [];
-                for (const role of roles) {
-                  const rolePermissions = await UserRoles.getPermissionsForRole(role, userContext);
-                  if (rolePermissions.status === "OK") {
-                    for (const perm of rolePermissions.permissions) {
-                      allPermissions.push(perm);
-                    }
-                  }
-                }
-
-                // Check if the user is associated with the tenant or not.
-                const userDetails = await getUser(session.getUserId(), userContext);
-                if (!userDetails?.tenantIds.some((id) => id.toLowerCase() === tenantId.toLowerCase())) {
-                  return {
-                    status: "ERROR_NOT_ALLOWED",
-                    message: "User is not associated with tenant",
-                  };
-                }
-
-                // User needs to have the tenant access permission
-                if (!allPermissions.includes(PERMISSIONS.TENANT_ACCESS)) {
-                  return {
-                    status: "ERROR_NOT_ALLOWED",
-                    message: "Requires tenant-access permission",
-                    roles: roles,
+                    message: reason,
                   };
                 }
 
@@ -953,7 +940,10 @@ export const init = createPluginInitFunction<
 
                 // We will add a new validator to check that the user
                 // can access the tenant.
-                const additionalValidators = [PermissionClaim.validators.includes(PERMISSIONS.TENANT_ACCESS)];
+                const additionalValidators = [
+                  PermissionClaim.validators.includes(PERMISSIONS.TENANT_ACCESS),
+                  TenantAccessPresentClaim.validators.isTrue(),
+                ];
                 logDebugMessage("Adding tenant-access permission claim");
 
                 if (pluginConfig.requireNonPublicTenantAssociation) {
@@ -1141,5 +1131,6 @@ export const init = createPluginInitFunction<
     enableTenantListAPI: config.enableTenantListAPI ?? false,
     createRolesOnInit: config.createRolesOnInit ?? true,
     emailDelivery: config.emailDelivery ?? undefined,
+    allowPublicTenantAccess: config.allowPublicTenantAccess ?? false,
   }),
 );

--- a/packages/tenants-nodejs/src/pluginImplementation.ts
+++ b/packages/tenants-nodejs/src/pluginImplementation.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import crypto from "crypto";
-import supertokens from "supertokens-node";
+import supertokens, { getUser } from "supertokens-node";
 import { SessionContainerInterface } from "supertokens-node/recipe/session/types";
 import MultiTenancy from "supertokens-node/recipe/multitenancy";
 import {
   InviteeDetails,
+  PERMISSIONS,
   ROLES,
   TenantCreationRequest,
   TenantCreationRequestWithUser,
@@ -552,6 +553,45 @@ export const getOverrideableTenantFunctionImplementation = (
        * @param role - The role to assign to the user.
        */
       return defaultAssignRoleToUserInTenant(tenantId, userId, role);
+    },
+    shouldHaveTenantAccess: async (userId: string, tenantId: string, userContext: UserContext) => {
+      /**
+       * Check if the passed user can access the tenant.
+       *
+       * We will check this by checking if they have the tenant-access permission.
+       */
+      // Check if the user has the role of member or admin in the tenant.
+      const roles = (await UserRoles.getRolesForUser(tenantId, userId, userContext)).roles;
+      if (roles.length === 0) {
+        return {
+          canAccess: false,
+          reason: "Cannot switch to tenant, not enough roles",
+        };
+      }
+
+      const allPermissions: string[] = [];
+      for (const role of roles) {
+        const rolePermissions = await UserRoles.getPermissionsForRole(role, userContext);
+        if (rolePermissions.status === "OK") {
+          for (const perm of rolePermissions.permissions) {
+            allPermissions.push(perm);
+          }
+        }
+      }
+
+      // Check if the user is associated with the tenant or not.
+      const userDetails = await getUser(userId, userContext);
+      if (!userDetails?.tenantIds.some((id) => id.toLowerCase() === tenantId.toLowerCase())) {
+        return {
+          canAccess: false,
+          reason: "User is not associated with tenant",
+        };
+      }
+
+      // User needs to have the tenant access permission
+      return {
+        canAccess: allPermissions.includes(PERMISSIONS.TENANT_ACCESS),
+      };
     },
   };
 

--- a/packages/tenants-nodejs/src/types.ts
+++ b/packages/tenants-nodejs/src/types.ts
@@ -45,6 +45,7 @@ export type SuperTokensPluginTenantPluginConfig = {
   requireTenantCreationRequestApproval?: boolean;
   enableTenantListAPI?: boolean;
   createRolesOnInit?: boolean;
+  allowPublicTenantAccess?: boolean;
 
   // Email delivery configuration - service is optional, override can provide sendEmail implementation
   emailDelivery?: {
@@ -60,6 +61,7 @@ export type SuperTokensPluginTenantPluginNormalisedConfig = {
   requireTenantCreationRequestApproval: boolean;
   enableTenantListAPI: boolean;
   createRolesOnInit: boolean;
+  allowPublicTenantAccess: boolean;
 
   // Email delivery configuration - service is optional, override can provide sendEmail implementation
   emailDelivery?: {
@@ -177,4 +179,9 @@ export type OverrideableTenantFunctionImplementation = {
   doesUserHaveTenantCreationRequest: (userId: string, metadata: TenantCreationRequestMetadataType) => Promise<boolean>;
   getPreferredTenantId: (tenantIds: string[], inputTenantId: string) => string | undefined;
   assignRoleToUserInTenant: (tenantId: string, userId: string, role: string) => Promise<void>;
+  shouldHaveTenantAccess: (
+    userId: string,
+    tenantId: string,
+    userContext: UserContext,
+  ) => Promise<{ canAccess: boolean; reason?: string }>;
 };

--- a/packages/tenants-react/src/plugin.tsx
+++ b/packages/tenants-react/src/plugin.tsx
@@ -54,6 +54,14 @@ export const init = createPluginInitFunction<
       },
     });
 
+    const TenantAccessPresentClaim = new BooleanClaim({
+      id: "stpl-tm-access",
+      refresh: async () => {},
+      onFailureRedirection: async () => {
+        return "/user/tenants/blocked";
+      },
+    });
+
     const extractCodeAndTenantId = (url: string) => {
       const urlParams = new URL(url).searchParams;
       const code = urlParams.get("tenantInviteCode");
@@ -234,7 +242,7 @@ export const init = createPluginInitFunction<
           functions: (originalImplementation) => {
             return {
               ...originalImplementation,
-              getGlobalClaimValidators(input) {
+              getGlobalClaimValidators: (input) => {
                 // If the profile claim is present, make sure the tenant
                 // one is added after it.
                 const updatedValidators = originalImplementation.getGlobalClaimValidators(input);
@@ -248,16 +256,7 @@ export const init = createPluginInitFunction<
 
                 // Add the permission check after the multiple tenants present claim
                 // is added.
-                updatedValidators.push({
-                  ...UserRoles.PermissionClaim.validators.includes(
-                    PERMISSIONS.TENANT_ACCESS,
-                    undefined,
-                    "stpl-tm-access",
-                  ),
-                  onFailureRedirection: () => {
-                    return "/user/tenants/blocked";
-                  },
-                });
+                updatedValidators.push(TenantAccessPresentClaim.validators.isTrue());
 
                 logDebugMessage(`updated validators: ${JSON.stringify(updatedValidators)}`);
                 return updatedValidators;


### PR DESCRIPTION
This PR adds support for a config flat that allows opting out of the tenant access blocked page for `public` tenants.