### PR TITLE
improv: Add utilities to generate magic links that can bypass cross d…

### DIFF
--- a/packages/rownd-nodejs/src/constants.ts
+++ b/packages/rownd-nodejs/src/constants.ts
@@ -47,3 +47,9 @@ export const DEFAULT_ROWND_SCHEMA: RowndSchema = {
 
 export const HUB_LOGIN_PAGE_PATH = "/account/login";
 export const HUB_VERIFY_EMAIL_PAGE_PATH = "/account/verify-email";
+export const PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PARAM =
+  "bypassDeviceConfirmation";
+export const PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_TOKEN_PARAM =
+  "bypassDeviceConfirmationToken";
+export const PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PURPOSE =
+  "rownd_passwordless_cross_device_confirmation_bypass";

--- a/packages/rownd-nodejs/src/index.ts
+++ b/packages/rownd-nodejs/src/index.ts
@@ -5,4 +5,12 @@ export default { init };
 export * from "./types";
 export * from "./constants";
 export * from "./errors";
+export {
+  createMagicLinkWithConfirmationBypass,
+  verifyPasswordlessConfirmationBypass,
+} from "./supertokens-repository";
+export type {
+  CreateMagicLinkWithConfirmationBypassInput,
+  VerifyPasswordlessConfirmationBypassInput,
+} from "./supertokens-repository";
 export { setRowndClient, getRowndClient } from "./rownd-repository";

--- a/packages/rownd-nodejs/src/plugin.test.ts
+++ b/packages/rownd-nodejs/src/plugin.test.ts
@@ -50,7 +50,9 @@ import {
   RowndIsAnonymousClaim,
   buildRowndSessionClaims,
   completePendingEmailVerification,
+  createMagicLinkWithConfirmationBypass,
   recordRowndAppVariantForUser,
+  verifyPasswordlessConfirmationBypass,
 } from "./supertokens-repository";
 
 let testPORT = 30001;
@@ -615,6 +617,140 @@ describe("rownd-nodejs plugin", () => {
       expect(rewrittenUrl.pathname).toBe("/account/login");
       expect(rewrittenUrl.searchParams.get("displayContext")).toBe("browser");
       expect(rewrittenUrl.hash).toBe("#abc");
+    });
+
+    it("creates a signed passwordless magic link that bypasses cross-device confirmation", async () => {
+      const pluginConfig: RowndPluginConfig = {
+        rowndAppKey: "test-key",
+        rowndAppSecret: "test-secret",
+        clientDomains: { browser_local: "http://localhost:3000" },
+      };
+      const { server: s, port } = await setup(coreConnectionURI, pluginConfig);
+      server = s;
+      testPORT = port;
+      const stConfig = makePublicConfig(
+        `http://localhost:${port}`,
+        "/auth",
+        `http://localhost:${port + 1}`,
+      ) as any;
+
+      const link = await createMagicLinkWithConfirmationBypass({
+        stConfig,
+        pluginConfig,
+        email: "bypass@example.com",
+        clientDomain: "browser_local",
+        redirectToPath: "http://localhost:3000/profile?tab=security",
+        displayContext: "browser",
+      });
+      const url = new URL(link);
+
+      expect(url.origin).toBe("http://localhost:3000");
+      expect(url.pathname).toBe("/account/login");
+      expect(url.searchParams.get("bypassDeviceConfirmation")).toBe("true");
+      expect(url.searchParams.get("bypassDeviceConfirmationToken")).toBeTruthy();
+      expect(url.searchParams.get("redirectToPath")).toBe("/profile?tab=security");
+      expect(url.searchParams.get("clientDomain")).toBe("browser_local");
+
+      await expect(
+        verifyPasswordlessConfirmationBypass({
+          stConfig,
+          pluginConfig,
+          token: url.searchParams.get("bypassDeviceConfirmationToken") || undefined,
+          preAuthSessionId: url.searchParams.get("preAuthSessionId") || undefined,
+          tenantId: url.searchParams.get("tenantId") || undefined,
+          clientDomain: "browser_local",
+          redirectToPath: "/profile?tab=security",
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it("rejects bypass magic links for unknown client domain keys", async () => {
+      const pluginConfig: RowndPluginConfig = {
+        rowndAppKey: "test-key",
+        rowndAppSecret: "test-secret",
+        clientDomains: { browser_local: "http://localhost:3000" },
+      };
+      const { server: s, port } = await setup(coreConnectionURI, pluginConfig);
+      server = s;
+      testPORT = port;
+      const stConfig = makePublicConfig(
+        `http://localhost:${port}`,
+        "/auth",
+        `http://localhost:${port + 1}`,
+      ) as any;
+
+      await expect(
+        createMagicLinkWithConfirmationBypass({
+          stConfig,
+          pluginConfig,
+          email: "bypass@example.com",
+          clientDomain: "http://localhost:3000",
+        }),
+      ).rejects.toThrow("Unknown clientDomain key");
+    });
+
+    it("rejects bypass magic links for cross-domain redirects", async () => {
+      const pluginConfig: RowndPluginConfig = {
+        rowndAppKey: "test-key",
+        rowndAppSecret: "test-secret",
+        clientDomains: { browser_local: "http://localhost:3000" },
+      };
+      const { server: s, port } = await setup(coreConnectionURI, pluginConfig);
+      server = s;
+      testPORT = port;
+      const stConfig = makePublicConfig(
+        `http://localhost:${port}`,
+        "/auth",
+        `http://localhost:${port + 1}`,
+      ) as any;
+
+      await expect(
+        createMagicLinkWithConfirmationBypass({
+          stConfig,
+          pluginConfig,
+          email: "bypass@example.com",
+          clientDomain: "browser_local",
+          redirectToPath: "https://evil.example.com/profile",
+        }),
+      ).rejects.toThrow("redirectToPath must match clientDomain");
+    });
+
+    it("rejects confirmation bypass verification for mismatched client domains", async () => {
+      const pluginConfig: RowndPluginConfig = {
+        rowndAppKey: "test-key",
+        rowndAppSecret: "test-secret",
+        clientDomains: {
+          browser_local: "http://localhost:3000",
+          browser_other: "http://localhost:3001",
+        },
+      };
+      const { server: s, port } = await setup(coreConnectionURI, pluginConfig);
+      server = s;
+      testPORT = port;
+      const stConfig = makePublicConfig(
+        `http://localhost:${port}`,
+        "/auth",
+        `http://localhost:${port + 1}`,
+      ) as any;
+
+      const link = await createMagicLinkWithConfirmationBypass({
+        stConfig,
+        pluginConfig,
+        email: "bypass@example.com",
+        clientDomain: "browser_local",
+      });
+      const url = new URL(link);
+
+      await expect(
+        verifyPasswordlessConfirmationBypass({
+          stConfig,
+          pluginConfig,
+          token: url.searchParams.get("bypassDeviceConfirmationToken") || undefined,
+          preAuthSessionId: url.searchParams.get("preAuthSessionId") || undefined,
+          tenantId: url.searchParams.get("tenantId") || undefined,
+          clientDomain: "browser_other",
+        }),
+      ).resolves.toBe(false);
     });
 
     it("adds hub bootstrap params to passwordless SMS magic links", async () => {
@@ -4608,7 +4744,7 @@ function makeRequest(query: Record<string, string>) {
   };
 }
 
-function makePublicConfig(apiDomain: string, apiBasePath: string) {
+function makePublicConfig(apiDomain: string, apiBasePath: string, websiteDomain = "https://hub.example.com") {
   return {
     appInfo: {
       apiDomain: {
@@ -4617,6 +4753,12 @@ function makePublicConfig(apiDomain: string, apiBasePath: string) {
       apiBasePath: {
         getAsStringDangerous: () => apiBasePath,
       },
+      websiteBasePath: {
+        getAsStringDangerous: () => "/auth",
+      },
+      getOrigin: () => ({
+        getAsStringDangerous: () => websiteDomain,
+      }),
       appName: "Test App",
     },
   };

--- a/packages/rownd-nodejs/src/plugin.ts
+++ b/packages/rownd-nodejs/src/plugin.ts
@@ -16,7 +16,10 @@ import {
 import { RowndPluginConfig, RowndPluginNormalisedConfig } from "./types";
 import { enableDebugLogs, logDebugMessage } from "./logger";
 import { createClient } from "./telemetry/createTelemetryClient";
-import { assertRowndAppVariantIsConfigured, setPluginConfig } from "./config";
+import {
+  assertRowndAppVariantIsConfigured,
+  setPluginConfig,
+} from "./config";
 import { shouldLinkRowndAccounts } from "./rownd-compatibility";
 import { setRowndClient } from "./rownd-repository";
 import {
@@ -39,6 +42,7 @@ import {
   handleGetUser,
   handleGetUserField,
   handleGetUserMeta,
+  handleVerifyPasswordlessConfirmationBypass,
   handleGuestLogin,
   handleMigrate,
   handleSignOut,
@@ -163,6 +167,13 @@ export const init: (config: RowndPluginConfig) => SuperTokensPlugin =
                 path: `${apiBasePath}${HANDLE_BASE_PATH}/guest`,
                 method: "post" as const,
                 handler: withRequestHandler(handleGuestLogin(routeHandlerDeps)),
+              },
+              {
+                path: `${apiBasePath}${HANDLE_BASE_PATH}/passwordless/bypass-device-confirmation/verify`,
+                method: "post" as const,
+                handler: withRequestHandler(
+                  handleVerifyPasswordlessConfirmationBypass(routeHandlerDeps),
+                ),
               },
               {
                 path: `${apiBasePath}${HANDLE_BASE_PATH}/migrate`,

--- a/packages/rownd-nodejs/src/pluginImplementation.ts
+++ b/packages/rownd-nodejs/src/pluginImplementation.ts
@@ -38,12 +38,14 @@ import {
   startPendingEmailVerification,
   updateUserData,
   updateUserMetadata,
+  verifyPasswordlessConfirmationBypass,
 } from "./supertokens-repository";
 import {
   getErrorMessage,
   getJsonBody,
   getRequestedAppVariantIdFromRequest,
   hasOwn,
+  isJsonRecord,
   missingFieldResponse,
   parseGuestBody,
   parseRequest,
@@ -173,6 +175,43 @@ export function handleGuestLogin(deps: RowndRouteHandlerDeps) {
       return {
         status: "ERROR" as const,
         message: "Guest login failed",
+      };
+    }
+  };
+}
+
+export function handleVerifyPasswordlessConfirmationBypass(deps: RowndRouteHandlerDeps) {
+  return async (req: SuperTokensRequest) => {
+    try {
+      const body = await getJsonBody(req);
+      const input = isJsonRecord(body) ? body : {};
+      const bypass = await verifyPasswordlessConfirmationBypass({
+        stConfig: deps.stConfig,
+        pluginConfig: deps.pluginConfig,
+        token: typeof input.token === "string" ? input.token : undefined,
+        preAuthSessionId: typeof input.preAuthSessionId === "string"
+          ? input.preAuthSessionId
+          : undefined,
+        tenantId: typeof input.tenantId === "string" ? input.tenantId : undefined,
+        clientDomain: typeof input.clientDomain === "string"
+          ? input.clientDomain
+          : undefined,
+        redirectToPath: typeof input.redirectToPath === "string"
+          ? input.redirectToPath
+          : undefined,
+        appVariantId: typeof input.appVariantId === "string"
+          ? input.appVariantId
+          : undefined,
+      });
+
+      return {
+        status: "OK" as const,
+        bypass,
+      };
+    } catch {
+      return {
+        status: "OK" as const,
+        bypass: false,
       };
     }
   };

--- a/packages/rownd-nodejs/src/supertokens-repository.ts
+++ b/packages/rownd-nodejs/src/supertokens-repository.ts
@@ -1,16 +1,25 @@
+import { createPublicKey, createVerify } from "node:crypto";
 import SuperTokens from "supertokens-node";
 import AccountLinking from "supertokens-node/recipe/accountlinking";
 import EmailVerification from "supertokens-node/recipe/emailverification";
 import Passwordless from "supertokens-node/recipe/passwordless";
 import Session from "supertokens-node/recipe/session";
 import { BooleanClaim } from "supertokens-node/recipe/session/claims";
+import type { SessionContainerInterface } from "supertokens-node/recipe/session/types";
 import UserMetadata from "supertokens-node/recipe/usermetadata";
 import type { JSONObject, SuperTokensPublicConfig } from "supertokens-node/types";
 
-import { DEFAULT_ROWND_SCHEMA, GUEST_AUTH_METHOD_ID, PUBLIC_TENANT_ID } from "./constants";
+import {
+  DEFAULT_ROWND_SCHEMA,
+  GUEST_AUTH_METHOD_ID,
+  PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PARAM,
+  PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PURPOSE,
+  PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_TOKEN_PARAM,
+  PUBLIC_TENANT_ID,
+} from "./constants";
 import { RowndPluginError } from "./errors";
 import { assertRowndAppVariantIsConfigured, getPluginConfig } from "./config";
-import type { SuperTokensUserImport } from "./types";
+import type { RowndPluginNormalisedConfig, SuperTokensUserImport } from "./types";
 import {
   buildRowndSessionClaimPayload,
   getEffectiveAuthLevel,
@@ -27,10 +36,108 @@ import {
 } from "./rownd-compatibility";
 import {
   getStringList,
+  getAppInfoString,
+  getMagicLinkBootstrapParams,
+  getRequiredSearchParam,
+  getWebsiteDomain,
   isJsonRecord,
   isRecord,
+  normalizeRedirectToPathForClientDomain,
+  resolveAllowedClientDomain,
+  rewriteMagicLink,
+  decodeBase64UrlJson,
   type JsonRecord,
 } from "./utils";
+
+const DEFAULT_BYPASS_TOKEN_VALIDITY_SECONDS = 300;
+
+type BypassDisplayContext = "browser" | "mobile_app" | "customer_web_view";
+
+export type CreateMagicLinkWithConfirmationBypassInput = {
+  stConfig: SuperTokensPublicConfig;
+  pluginConfig: RowndPluginNormalisedConfig;
+  email?: string;
+  phoneNumber?: string;
+  tenantId?: string;
+  request?: any;
+  session?: SessionContainerInterface;
+  userContext?: Record<string, any>;
+  redirectToPath?: string;
+  clientDomain?: string;
+  displayContext?: BypassDisplayContext;
+  appVariantId?: string;
+  validitySeconds?: number;
+};
+
+export type VerifyPasswordlessConfirmationBypassInput = {
+  stConfig: SuperTokensPublicConfig;
+  pluginConfig: RowndPluginNormalisedConfig;
+  token?: string;
+  preAuthSessionId?: string;
+  tenantId?: string;
+  clientDomain?: string;
+  redirectToPath?: string;
+  appVariantId?: string;
+};
+
+type BypassTokenPayload = {
+  purpose?: string;
+  preAuthSessionId?: string;
+  tenantId?: string;
+  clientDomain?: string;
+  redirectToPath?: string;
+  appVariantId?: string;
+  exp?: number;
+  nbf?: number;
+};
+
+function parseJwt(token: string) {
+  const parts = token.split(".");
+  const [headerPart, payloadPart, signaturePart] = parts;
+  if (parts.length !== 3 || !headerPart || !payloadPart || !signaturePart) {
+    throw new Error("Invalid JWT format");
+  }
+
+  return {
+    signingInput: `${headerPart}.${payloadPart}`,
+    signature: Buffer.from(signaturePart, "base64url"),
+    header: decodeBase64UrlJson<{ alg?: string; kid?: string }>(headerPart),
+    payload: decodeBase64UrlJson<BypassTokenPayload>(payloadPart),
+  };
+}
+
+async function verifyJwtSignature(token: string) {
+  const parsed = parseJwt(token);
+  if (parsed.header.alg !== "RS256") {
+    throw new Error("Unsupported JWT algorithm");
+  }
+
+  const jwks = await Session.getJWKS();
+  const keys = parsed.header.kid
+    ? jwks.keys.filter((key) => key.kid === parsed.header.kid)
+    : jwks.keys;
+
+  for (const key of keys) {
+    try {
+      const verifier = createVerify("RSA-SHA256");
+      verifier.update(parsed.signingInput);
+      verifier.end();
+      const publicKey = createPublicKey({ key, format: "jwk" });
+      if (verifier.verify(publicKey, parsed.signature)) {
+        return parsed.payload;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error("Invalid JWT signature");
+}
+
+function isTokenTimeValid(payload: BypassTokenPayload) {
+  const now = Math.floor(Date.now() / 1000);
+  return (payload.exp === undefined || payload.exp > now) && (payload.nbf === undefined || payload.nbf <= now);
+}
 
 export async function importUser(
   stUser: SuperTokensUserImport,
@@ -146,6 +253,131 @@ export async function buildRowndSessionClaims(
     currentPayload,
     appVariantId,
   });
+}
+
+export async function createMagicLinkWithConfirmationBypass(
+  input: CreateMagicLinkWithConfirmationBypassInput,
+) {
+  const hasEmail = typeof input.email === "string" && input.email.length > 0;
+  const hasPhoneNumber = typeof input.phoneNumber === "string" && input.phoneNumber.length > 0;
+
+  if (hasEmail === hasPhoneNumber) {
+    throw new Error("Exactly one of email or phoneNumber is required");
+  }
+
+  const tenantId = input.tenantId ?? PUBLIC_TENANT_ID;
+  const appVariantId = input.appVariantId;
+  assertRowndAppVariantIsConfigured(appVariantId);
+
+  const clientDomain = resolveAllowedClientDomain({
+    clientDomain: input.clientDomain,
+    pluginConfig: input.pluginConfig,
+    stConfig: input.stConfig,
+    request: input.request,
+    userContext: input.userContext,
+  });
+  const redirectToPath = normalizeRedirectToPathForClientDomain(input.redirectToPath, clientDomain);
+  const apiDomain = getAppInfoString(input.stConfig.appInfo.apiDomain);
+  const apiBasePath = getAppInfoString(input.stConfig.appInfo.apiBasePath);
+  const userContext = {
+    ...(input.userContext ?? {}),
+    ...(input.displayContext ? { rowndDisplayContext: input.displayContext } : {}),
+    ...(redirectToPath ? { rowndRedirectToPath: redirectToPath } : {}),
+    ...(input.clientDomain ? { rowndClientDomain: input.clientDomain } : {}),
+    ...(appVariantId ? { rowndAppVariantId: appVariantId } : {}),
+  };
+  const codeInfo = hasEmail
+    ? await Passwordless.createCode({
+      email: input.email!,
+      tenantId,
+      session: input.session,
+      userContext,
+    })
+    : await Passwordless.createCode({
+      phoneNumber: input.phoneNumber!,
+      tenantId,
+      session: input.session,
+      userContext,
+    });
+
+  if (codeInfo.status !== "OK") {
+    throw new Error("Failed to create magic link");
+  }
+
+  const magicLink = `${getWebsiteDomain({
+    stConfig: input.stConfig,
+    request: input.request,
+    userContext,
+  })}${getAppInfoString(input.stConfig.appInfo.websiteBasePath)}/verify?preAuthSessionId=${encodeURIComponent(
+    codeInfo.preAuthSessionId,
+  )}&tenantId=${encodeURIComponent(tenantId)}#${encodeURIComponent(codeInfo.linkCode)}`;
+  const rewrittenLink = rewriteMagicLink({
+    magicLink,
+    clientDomain,
+    bootstrapParams: getMagicLinkBootstrapParams({
+      appKey: input.pluginConfig.rowndAppKey,
+      apiDomain,
+      apiBasePath,
+      appVariantId,
+      displayContext: input.displayContext,
+      redirectToPath,
+      clientDomainKey: input.clientDomain,
+    }),
+  });
+  const rewrittenUrl = new URL(rewrittenLink);
+  const preAuthSessionId = getRequiredSearchParam(rewrittenUrl, "preAuthSessionId");
+  const linkTenantId = getRequiredSearchParam(rewrittenUrl, "tenantId");
+  const jwtResponse = await Session.createJWT(
+    {
+      purpose: PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PURPOSE,
+      preAuthSessionId,
+      tenantId: linkTenantId,
+      clientDomain,
+      ...(redirectToPath ? { redirectToPath } : {}),
+      ...(appVariantId ? { appVariantId } : {}),
+    },
+    input.validitySeconds ?? DEFAULT_BYPASS_TOKEN_VALIDITY_SECONDS,
+  );
+
+  if (jwtResponse.status !== "OK") {
+    throw new Error("Failed to create confirmation bypass token");
+  }
+
+  rewrittenUrl.searchParams.set(PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PARAM, "true");
+  rewrittenUrl.searchParams.set(PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_TOKEN_PARAM, jwtResponse.jwt);
+
+  return rewrittenUrl.toString();
+}
+
+export async function verifyPasswordlessConfirmationBypass(
+  input: VerifyPasswordlessConfirmationBypassInput,
+) {
+  try {
+    if (!input.token || !input.preAuthSessionId) {
+      return false;
+    }
+
+    const tenantId = input.tenantId ?? PUBLIC_TENANT_ID;
+    const clientDomain = resolveAllowedClientDomain({
+      clientDomain: input.clientDomain,
+      pluginConfig: input.pluginConfig,
+      stConfig: input.stConfig,
+    });
+    const redirectToPath = normalizeRedirectToPathForClientDomain(input.redirectToPath, clientDomain);
+    const payload = await verifyJwtSignature(input.token);
+
+    return Boolean(
+      isTokenTimeValid(payload) &&
+        payload.purpose === PASSWORDLESS_BYPASS_DEVICE_CONFIRMATION_PURPOSE &&
+        payload.preAuthSessionId === input.preAuthSessionId &&
+        payload.tenantId === tenantId &&
+        payload.clientDomain === clientDomain &&
+        (payload.redirectToPath ?? undefined) === (redirectToPath ?? undefined) &&
+        (payload.appVariantId ?? undefined) === (input.appVariantId ?? undefined)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function getUserMetadata(userId: string): Promise<RowndMetadata> {

--- a/packages/rownd-nodejs/src/utils.ts
+++ b/packages/rownd-nodejs/src/utils.ts
@@ -1,6 +1,9 @@
 import type { JSONObject, PluginRouteHandler } from "supertokens-node/types";
+import type { SuperTokensPublicConfig } from "supertokens-node/types";
 
+import { HUB_LOGIN_PAGE_PATH } from "./constants";
 import { RowndPluginError } from "./errors";
+import type { RowndPluginNormalisedConfig } from "./types";
 
 type SuperTokensRequest = Parameters<PluginRouteHandler["handler"]>[0];
 export type JsonRecord = JSONObject;
@@ -158,6 +161,184 @@ export function getStringList(value: unknown) {
 
 export function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Unknown error";
+}
+
+export function getAppInfoString(value: { getAsStringDangerous: () => string }) {
+  return value.getAsStringDangerous();
+}
+
+export function getWebsiteDomain(input: {
+  stConfig: SuperTokensPublicConfig;
+  request?: any;
+  userContext?: Record<string, any>;
+}) {
+  return getAppInfoString(input.stConfig.appInfo.getOrigin({
+    request: input.request,
+    userContext: (input.userContext ?? {}) as any,
+  }));
+}
+
+export function normalizeClientDomain(value: string) {
+  if (value.endsWith("://")) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.origin;
+    }
+
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    throw new Error(`Invalid clientDomain: ${value}`);
+  }
+}
+
+function resolveClientDomain(input: {
+  clientDomain?: string;
+  pluginConfig: RowndPluginNormalisedConfig;
+  websiteDomain: string;
+}) {
+  if (!input.clientDomain) {
+    return input.websiteDomain;
+  }
+
+  const resolved = input.pluginConfig.clientDomains?.[input.clientDomain];
+  if (!resolved) {
+    throw new Error(`Unknown clientDomain key: ${input.clientDomain}`);
+  }
+
+  return resolved;
+}
+
+function assertAllowedClientDomain(input: {
+  clientDomain: string;
+  pluginConfig: RowndPluginNormalisedConfig;
+  websiteDomain: string;
+}) {
+  const normalizedClientDomain = normalizeClientDomain(input.clientDomain);
+  const allowed = [
+    input.websiteDomain,
+    ...Object.values(input.pluginConfig.clientDomains ?? {}),
+  ].map(normalizeClientDomain);
+
+  if (!allowed.includes(normalizedClientDomain)) {
+    throw new Error(`clientDomain is not allowed: ${input.clientDomain}`);
+  }
+
+  return normalizedClientDomain;
+}
+
+export function resolveAllowedClientDomain(input: {
+  clientDomain?: string;
+  pluginConfig: RowndPluginNormalisedConfig;
+  stConfig: SuperTokensPublicConfig;
+  request?: any;
+  userContext?: Record<string, any>;
+}) {
+  const websiteDomain = getWebsiteDomain(input);
+  const resolvedClientDomain = resolveClientDomain({
+    clientDomain: input.clientDomain,
+    pluginConfig: input.pluginConfig,
+    websiteDomain,
+  });
+
+  return assertAllowedClientDomain({
+    clientDomain: resolvedClientDomain,
+    pluginConfig: input.pluginConfig,
+    websiteDomain,
+  });
+}
+
+export function normalizeRedirectToPathForClientDomain(
+  redirectToPath: string | undefined,
+  clientDomain: string,
+) {
+  if (!redirectToPath) {
+    return undefined;
+  }
+
+  if (redirectToPath === "NATIVE_APP") {
+    return redirectToPath;
+  }
+
+  if (redirectToPath.startsWith("//")) {
+    throw new Error("redirectToPath cannot be schemaless");
+  }
+
+  const normalizedClientDomain = normalizeClientDomain(clientDomain);
+
+  try {
+    const redirectUrl = new URL(
+      redirectToPath,
+      normalizedClientDomain.endsWith("://") ? "http://localhost" : normalizedClientDomain,
+    );
+    const hasExplicitScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(redirectToPath);
+
+    if (hasExplicitScheme) {
+      if (redirectUrl.protocol !== "http:" && redirectUrl.protocol !== "https:") {
+        throw new Error("redirectToPath must be http(s) or relative");
+      }
+
+      if (redirectUrl.origin !== normalizedClientDomain) {
+        throw new Error("redirectToPath must match clientDomain");
+      }
+    }
+
+    return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
+  } catch (err) {
+    if (err instanceof Error) {
+      throw err;
+    }
+
+    throw new Error("Invalid redirectToPath");
+  }
+}
+
+export function getMagicLinkBootstrapParams(input: {
+  appKey: string;
+  apiDomain: string;
+  apiBasePath: string;
+  appVariantId?: string;
+  displayContext?: "browser" | "mobile_app" | "customer_web_view";
+  redirectToPath?: string;
+  clientDomainKey?: string;
+}) {
+  return {
+    appKey: input.appKey,
+    apiDomain: input.apiDomain,
+    apiBasePath: input.apiBasePath,
+    ...(input.appVariantId ? { appVariantId: input.appVariantId } : {}),
+    ...(input.displayContext ? { displayContext: input.displayContext } : {}),
+    ...(input.redirectToPath ? { redirectToPath: input.redirectToPath } : {}),
+    ...(input.clientDomainKey ? { clientDomain: input.clientDomainKey } : {}),
+  };
+}
+
+export function rewriteMagicLink(input: {
+  magicLink: string;
+  clientDomain: string;
+  bootstrapParams: Record<string, string>;
+}) {
+  return rewriteLinkToBaseUrl(
+    input.magicLink,
+    HUB_LOGIN_PAGE_PATH,
+    input.clientDomain,
+    input.bootstrapParams,
+  );
+}
+
+export function getRequiredSearchParam(url: URL, name: string) {
+  const value = url.searchParams.get(name);
+  if (!value) {
+    throw new Error(`Magic link is missing ${name}`);
+  }
+  return value;
+}
+
+export function decodeBase64UrlJson<T>(value: string): T {
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as T;
 }
 
 export function getRequestedAppVariantIdFromRequest(


### PR DESCRIPTION
Adds a signed passwordless magic-link flow for trusted cross-device confirmation bypasses.

The plugin now exposes helpers to create and verify bypass-enabled magic links using SuperTokens-signed JWTs. Bypass links are only issued for allowed client domains and validate post-login redirects before signing. A new verify endpoint lets the hub confirm the bypass token before skipping the cross-device confirmation screen, while normal passwordless consume behavior remains unchanged.